### PR TITLE
Feature/remove uninitialized warning

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
+    - Remove uninitialized warning when config file is not defined
 
 0.002     2015-07-02 15:54:42+09:00 Asia/Seoul
     - Enable config root is selective

--- a/lib/OpenCloset/Config.pm
+++ b/lib/OpenCloset/Config.pm
@@ -11,11 +11,14 @@ our $VERSION = '0.003';
 
 sub load {
     my $conf_file = shift;
-    my %opt; %opt = %{ shift; } if ref $_[0] eq 'HASH';
-    my %default   = @_;
+    my %opt;
+    %opt = %{ shift; } if ref $_[0] eq "HASH";
+    my %default = @_;
 
-    $conf_file ||= $ENV{OPENCLOSET_CONFIG};
-    die "cannot find config file\n" unless -e $conf_file;
+    $conf_file ||= $ENV{OPENCLOSET_CONFIG} || q{};
+    die
+        "Cannot find config file. You can set OPENCLOSET_CONFIG environment variable for default config file path.\n"
+        unless -e $conf_file;
     my $conf = eval path($conf_file)->slurp_utf8;
 
     my %real_conf;


### PR DESCRIPTION
설정 파일 값이 없을 때 초기화 되지 않은 값 관련 경고가 발생하는 것을 방지합니다.
